### PR TITLE
Wrap include <cblas.h> in extern "C" because on some Linuxes this system...

### DIFF
--- a/Analysis/BkgModel/BkgFitMatrixPacker.h
+++ b/Analysis/BkgModel/BkgFitMatrixPacker.h
@@ -17,7 +17,9 @@
 #ifdef ION_USE_MKL
 #include <mkl_cblas.h>
 #else
+extern "C" {
 #include <cblas.h>
+}
 #endif
 
 //#define BKG_FIT_MAX_FLOWS   20


### PR DESCRIPTION
... header is missing extern C itself.  This should not break on Linuxes for which cblas.h is correct.
