### PR TITLE
bam2sff converting reads with homopolymer in last flow

### DIFF
--- a/Analysis/Converter/bam2sff.cpp
+++ b/Analysis/Converter/bam2sff.cpp
@@ -465,7 +465,7 @@ int main(int argc, const char *argv[])
 */
 		uint16_t nFlows2 = flow_order2.length();
 
-		while(nBase < sff->rheader->n_bases && nFlow < nFlows2)
+		while(nBase < sff->rheader->n_bases)
 		{
 		  if(bases[nBase] == preBase)
 		  {


### PR DESCRIPTION
If a read has a homopolymer at the last flow (`nFlow == nFlows2`) theres an error in the sff file, as the loop get skipped and `flow_index` won't get updated to 0 at the homopolymers positions (leaving it to whatever value the array had on this positions). 
This leads to flow indexes greater than the max number of flows.
Files with this error cann't be processed by newbler.

**Removing the unnecessary query in the loop corrects this errors.**
Another solution is to reinitialise flow_index with zeros for every read (very slow)

Attached is the sffinfo output of a defective converted read.

```
Common Header:
  Magic Number:  0x2E736666
  Version:       0001
  Index Offset:  0
  Index Length:  0
  # of Reads:    21666
  Header Length: 552
  Key Length:    17
  # of Flows:    500
  Flowgram Code: 1
  Flow Chars:    TACGTACGTCTGAGCATCGATCGATGTACAGCTACGTACGTCTGAGCATCGATCGATGTACAGCTACGTACGTCTGAGCATCGATCGATGTACAGCTACGTACGTCTGAGCATCGATCGATGTACAGCTACGTACGTCTGAGCATCGATCGATGTACAGCTACGTACGTCTGAGCATCGATCGATGTACAGCTACGTACGTCTGAGCATCGATCGATGTACAGCTACGTACGTCTGAGCATCGATCGATGTACAGCTACGTACGTCTGAGCATCGATCGATGTACAGCTACGTACGTCTGAGCATCGATCGATGTACAGCTACGTACGTCTGAGCATCGATCGATGTACAGCTACGTACGTCTGAGCATCGATCGATGTACAGCTACGTACGTCTGAGCATCGATCGATGTACAGCTACGTACGTCTGAGCATCGATCGATGTACAGCTACGTACGTCTGAGCATCGATCGATGTACAGCTACGTACGTCTGAGCATCGA
  Key Sequence:  TCAGTTGGAGTGTCGAT
```

```
>NIYW6:02297:02918
  Read Header Len:  40
  Name Length:      17
  # of Bases:       277
  Clip Qual Left:   18
  Clip Qual Right:  0
  Clip Adap Left:   0
  Clip Adap Right:  0

Flowgram:   0.93    0.04    0.98    0.02    0.07    0.96    0.05    1.06    2.04    0.00    0.00    2.06    0.99    1.01    0.03    0.00    1.00    0.03    1.02    0.00    0.80    0.93    0.93    0.82    0.93    0.03    0.00    0.92    0.00    0.00    0.10    0.00    2.82    0.04    0.00    1.97    0.96    0.00    0.00    2.83    0.19    0.94    0.00    1.06    0.00    0.00    0.95    0.89    0.08    0.00    1.04    0.00    0.00    0.96    1.88    0.00    0.00    0.10    0.00    0.00    1.04    0.07    1.17    0.99    0.00    0.02    0.00    2.85    0.00    0.00    0.96    0.21    0.00    0.16    0.00    0.17    0.97    0.03    0.93    0.10    0.04    0.09    1.07    0.00    0.00    1.08    0.97    0.03    0.02    0.09    0.00    0.00    3.71    0.94    2.57    1.90    0.00    0.92    0.00    0.09    0.85    0.00    1.03    0.89    0.00    0.93    0.00    0.02    1.94    2.75    0.98    0.10    0.02    0.00    1.07    0.85    0.00    0.16    1.03    0.15    0.02    0.19    0.00    0.00    1.01    0.00    3.81    0.90    0.00    0.08    0.00    1.85    0.00    0.00    1.00    1.10    0.00    2.70    0.00    0.08    1.79    0.00    0.25    0.07    0.82    0.00    1.01    0.00    0.00    1.00    0.99    0.00    0.03    0.04    0.00    0.00    1.00    0.00    0.10    0.07    0.97    0.04    0.93    0.02    0.00    0.92    0.06    0.09    0.96    0.05    0.00    0.53    0.67    0.67    2.07    0.96    0.00    0.00    0.98    0.00    0.00    1.03    0.94    0.10    0.00    0.01    0.00    0.00    1.93    0.00    0.07    0.07    0.95    0.00    0.00    1.99    2.87    0.00    1.00    1.93    0.01    0.95    1.79    0.14    0.00    0.00    1.00    0.01    0.21    0.09    1.98    0.01    0.01    1.93    1.82    0.02    0.01    0.01    0.01    0.01    0.93    0.01    0.98    0.04    0.03    0.82    0.01    0.16    0.87    0.01    1.03    0.93    0.01    0.87    0.08    1.66    0.07    0.02    0.88    0.02    2.70    0.03    1.03    0.02    0.02    1.82    0.92    0.02    0.93    0.02    0.02    0.02    1.07    0.02    0.88    0.79    0.19    0.02    0.03    0.81    0.02    0.05    1.10    0.10    0.17    0.08    0.03    0.12    0.85    0.03    0.14    0.03    0.95    0.03    0.11    0.85    0.03    1.01    0.05    0.03    1.93    0.90    0.03    0.03    2.68    0.04    0.78    0.25    0.91    0.92    0.03    0.20    0.92    0.04    1.05    0.90    0.17    1.82    0.04    0.79    1.01    0.06    1.03    0.82    0.04    0.04    1.04    0.17    0.05    1.63    0.63    0.11    1.63    0.11    0.05    0.05    1.25    0.06    1.05    0.06    0.33    0.94    1.67    1.73    0.27    0.88    1.14    0.50    0.79    0.10    0.06    1.41    0.21    0.06    1.75    0.71    0.19    0.06    1.92    0.05    0.66    0.47    0.83    0.21    0.25    0.42    0.10    0.05    0.98    0.06    1.07    0.17    0.67    0.08    0.64    0.85    0.14    0.04    1.42    0.21    0.09    0.31    0.04    0.16    1.00    0.82    1.07    0.14    0.04    0.04    0.96    1.68    0.06    1.03    0.11    1.17    0.04    0.04    0.05    0.04    1.07    0.96    0.21    0.19    0.82    0.21    0.91    0.11    0.15    1.60    0.98    0.77    0.75    0.05    0.13    0.06    1.12    0.04    1.70    0.04    0.21    0.05    1.05    0.89    0.89    0.85    0.04    0.35    1.46    0.87    1.34    0.07    0.60    0.04    0.89    0.92    0.82    0.12    0.07    1.60    0.19    0.75    1.91    0.19    0.92    0.09    0.13    1.48    0.35    0.04    1.67    0.04    0.46    0.04    1.14    1.52    0.07    1.16    0.14    0.91    0.21    0.21    0.04    0.26    1.29    0.07    0.67    0.17    0.86    0.03    0.62    1.15    0.08    0.66    0.69    0.35    0.81    0.11    0.03    0.03    1.62    0.03    0.86    0.07    0.73    0.17    0.80    0.49    0.18    0.96    1.28    0.15    0.90    0.08    0.01    0.89    0.50    0.01    0.35    0.14    0.86    0.23    0.53    0.82    0.15    0.21    0.96    1.06    0.17    0.64    0.01    0.17    0.78    0.33    0.93    0.14    0.21    0.15    0.95    1.56
Flow Indexes:   1   3   6   8   9   9   12  12  13  14  17  19  21  22  23  24  25  28  33  33  33  36  36  37  40  40  40  42  44  47  48  51  54  55  55  61  63  64  68  68  68  71  77  79  83  86  87  93  93  93  93  94  95  95  95  96  96  98  101 103 104 106 109 109 110 110 110 111 115 116 119 125 127 127 127 127 128 132 132 135 136 138 138 138 141 141 145 147 150 151 157 161 163 166 169 172 173 174 175 175 176 179 182 183 189 189 193 196 196 197 197 197 199 200 200 202 203 203 207 211 211 214 214 215 215 221 223 226 229 231 232 234 236 236 239 241 241 241 243 246 246 247 249 253 255 256 260 263 269 273 276 278 281 281 282 285 285 285 287 289 290 293 295 296 298 298 300 301 303 304 307 310 310 311 313 313 317 319 322 323 323 324 324 326 327 329 332 332 335 335 336 339 339 341 343 349 351 353 355 356 359 359 365 366 367 371 372 372 374 376 381 382 385 387 390 390 391 392 393 397 399 399 403 404 405 406 409 409 410 411 411 415 416 417 420 420 422 423 423 425 428 428 431 431 435 436 436 438 440 445 447 449 451 452 454 457 461 461 463 465 467 470 471 471 473 476 481 483 484 487 488 490 493 495 499 500 502
Bases:  tcagttggagtgtcgatATTTGGTGGGCGCAGCGGCGCGGGCACGCGCCCCAGGGCCATCGCAAGGGCGAGCGGGGCGGCGCCCAATGCGCTCATGAGCCAGCGCCTGGTTTCGGCTTCGGCCGGCGATCGCGGCTTTGCCGTCGCGCATACTTGCCCGTATCGCCGACAGCCGTTCGACCGGACTGGCCAGGTGCGTCGCCAGCGAACACATCAACGTACCGATCTTGTTGCTGGACCTGGCCGAACACGTCGATAACTGCGGTATCGCGCACGAA
```

**As you can see there is a flow index 502 in the read**

And the same read after correcting the script:

```
>NIYW6:02297:02918
  Read Header Len:  40
  Name Length:      17
  # of Bases:       277
  Clip Qual Left:   18
  Clip Qual Right:  0
  Clip Adap Left:   0
  Clip Adap Right:  0

Flowgram:   0.93    0.04    0.98    0.02    0.07    0.96    0.05    1.06    2.04    0.00    0.00    2.06    0.99    1.01    0.03    0.00    1.00    0.03    1.02    0.00    0.80    0.93    0.93    0.82    0.93    0.03    0.00    0.92    0.00    0.00    0.10    0.00    2.82    0.04    0.00    1.97    0.96    0.00    0.00    2.83    0.19    0.94    0.00    1.06    0.00    0.00    0.95    0.89    0.08    0.00    1.04    0.00    0.00    0.96    1.88    0.00    0.00    0.10    0.00    0.00    1.04    0.07    1.17    0.99    0.00    0.02    0.00    2.85    0.00    0.00    0.96    0.21    0.00    0.16    0.00    0.17    0.97    0.03    0.93    0.10    0.04    0.09    1.07    0.00    0.00    1.08    0.97    0.03    0.02    0.09    0.00    0.00    3.71    0.94    2.57    1.90    0.00    0.92    0.00    0.09    0.85    0.00    1.03    0.89    0.00    0.93    0.00    0.02    1.94    2.75    0.98    0.10    0.02    0.00    1.07    0.85    0.00    0.16    1.03    0.15    0.02    0.19    0.00    0.00    1.01    0.00    3.81    0.90    0.00    0.08    0.00    1.85    0.00    0.00    1.00    1.10    0.00    2.70    0.00    0.08    1.79    0.00    0.25    0.07    0.82    0.00    1.01    0.00    0.00    1.00    0.99    0.00    0.03    0.04    0.00    0.00    1.00    0.00    0.10    0.07    0.97    0.04    0.93    0.02    0.00    0.92    0.06    0.09    0.96    0.05    0.00    0.53    0.67    0.67    2.07    0.96    0.00    0.00    0.98    0.00    0.00    1.03    0.94    0.10    0.00    0.01    0.00    0.00    1.93    0.00    0.07    0.07    0.95    0.00    0.00    1.99    2.87    0.00    1.00    1.93    0.01    0.95    1.79    0.14    0.00    0.00    1.00    0.01    0.21    0.09    1.98    0.01    0.01    1.93    1.82    0.02    0.01    0.01    0.01    0.01    0.93    0.01    0.98    0.04    0.03    0.82    0.01    0.16    0.87    0.01    1.03    0.93    0.01    0.87    0.08    1.66    0.07    0.02    0.88    0.02    2.70    0.03    1.03    0.02    0.02    1.82    0.92    0.02    0.93    0.02    0.02    0.02    1.07    0.02    0.88    0.79    0.19    0.02    0.03    0.81    0.02    0.05    1.10    0.10    0.17    0.08    0.03    0.12    0.85    0.03    0.14    0.03    0.95    0.03    0.11    0.85    0.03    1.01    0.05    0.03    1.93    0.90    0.03    0.03    2.68    0.04    0.78    0.25    0.91    0.92    0.03    0.20    0.92    0.04    1.05    0.90    0.17    1.82    0.04    0.79    1.01    0.06    1.03    0.82    0.04    0.04    1.04    0.17    0.05    1.63    0.63    0.11    1.63    0.11    0.05    0.05    1.25    0.06    1.05    0.06    0.33    0.94    1.67    1.73    0.27    0.88    1.14    0.50    0.79    0.10    0.06    1.41    0.21    0.06    1.75    0.71    0.19    0.06    1.92    0.05    0.66    0.47    0.83    0.21    0.25    0.42    0.10    0.05    0.98    0.06    1.07    0.17    0.67    0.08    0.64    0.85    0.14    0.04    1.42    0.21    0.09    0.31    0.04    0.16    1.00    0.82    1.07    0.14    0.04    0.04    0.96    1.68    0.06    1.03    0.11    1.17    0.04    0.04    0.05    0.04    1.07    0.96    0.21    0.19    0.82    0.21    0.91    0.11    0.15    1.60    0.98    0.77    0.75    0.05    0.13    0.06    1.12    0.04    1.70    0.04    0.21    0.05    1.05    0.89    0.89    0.85    0.04    0.35    1.46    0.87    1.34    0.07    0.60    0.04    0.89    0.92    0.82    0.12    0.07    1.60    0.19    0.75    1.91    0.19    0.92    0.09    0.13    1.48    0.35    0.04    1.67    0.04    0.46    0.04    1.14    1.52    0.07    1.16    0.14    0.91    0.21    0.21    0.04    0.26    1.29    0.07    0.67    0.17    0.86    0.03    0.62    1.15    0.08    0.66    0.69    0.35    0.81    0.11    0.03    0.03    1.62    0.03    0.86    0.07    0.73    0.17    0.80    0.49    0.18    0.96    1.28    0.15    0.90    0.08    0.01    0.89    0.50    0.01    0.35    0.14    0.86    0.23    0.53    0.82    0.15    0.21    0.96    1.06    0.17    0.64    0.01    0.17    0.78    0.33    0.93    0.14    0.21    0.15    0.95    1.56
Flow Indexes:   1   3   6   8   9   9   12  12  13  14  17  19  21  22  23  24  25  28  33  33  33  36  36  37  40  40  40  42  44  47  48  51  54  55  55  61  63  64  68  68  68  71  77  79  83  86  87  93  93  93  93  94  95  95  95  96  96  98  101 103 104 106 109 109 110 110 110 111 115 116 119 125 127 127 127 127 128 132 132 135 136 138 138 138 141 141 145 147 150 151 157 161 163 166 169 172 173 174 175 175 176 179 182 183 189 189 193 196 196 197 197 197 199 200 200 202 203 203 207 211 211 214 214 215 215 221 223 226 229 231 232 234 236 236 239 241 241 241 243 246 246 247 249 253 255 256 260 263 269 273 276 278 281 281 282 285 285 285 287 289 290 293 295 296 298 298 300 301 303 304 307 310 310 311 313 313 317 319 322 323 323 324 324 326 327 329 332 332 335 335 336 339 339 341 343 349 351 353 355 356 359 359 365 366 367 371 372 372 374 376 381 382 385 387 390 390 391 392 393 397 399 399 403 404 405 406 409 409 410 411 411 415 416 417 420 420 422 423 423 425 428 428 431 431 435 436 436 438 440 445 447 449 451 452 454 457 461 461 463 465 467 470 471 471 473 476 481 483 484 487 488 490 493 495 499 500 500
Bases:  tcagttggagtgtcgatATTTGGTGGGCGCAGCGGCGCGGGCACGCGCCCCAGGGCCATCGCAAGGGCGAGCGGGGCGGCGCCCAATGCGCTCATGAGCCAGCGCCTGGTTTCGGCTTCGGCCGGCGATCGCGGCTTTGCCGTCGCGCATACTTGCCCGTATCGCCGACAGCCGTTCGACCGGACTGGCCAGGTGCGTCGCCAGCGAACACATCAACGTACCGATCTTGTTGCTGGACCTGGCCGAACACGTCGATAACTGCGGTATCGCGCACGAA
```
