### PR TITLE
Process results for each barcode immediately

### DIFF
--- a/plugin/variantCaller/variant_caller_plugin.py
+++ b/plugin/variantCaller/variant_caller_plugin.py
@@ -1318,26 +1318,30 @@ def process_configuration(barcoded_run, multisample, configuration_name, configu
             traceback.print_exc()
             for bam in configuration['bams']:
                 bam['status'] = 'error'
+                
+        for bam in configuration['bams']:
+            try:
+                bam['summary'] = process_results(barcoded_run, configuration, bam)
+                load_results_json(barcoded_run, configuration, bam, results_json)
+                bam['status'] = 'completed'
+                bams_processed.append(bam)
+            except:
+                traceback.print_exc()
+                bam['status'] = 'error'
+                bams_processed.append(bam)
     else:
         for bam in configuration['bams']:
             bams = []
             bams.append(bam)
             try:
                 variant_caller_pipeline(barcoded_run, multisample, bam['name'], configuration, bams)
+                bam['summary'] = process_results(barcoded_run, configuration, bam)
+                load_results_json(barcoded_run, configuration, bam, results_json)
+                bam['status'] = 'completed'
+                bams_processed.append(bam)
             except:
                 traceback.print_exc()
                 bam['status'] = 'error'
-
-    for bam in configuration['bams']:
-        try:
-            bam['summary'] = process_results(barcoded_run, configuration, bam)
-            load_results_json(barcoded_run, configuration, bam, results_json)
-            bam['status'] = 'completed'
-            bams_processed.append(bam)
-        except:
-            traceback.print_exc()
-            bam['status'] = 'error'
-            bams_processed.append(bam)
         
 def plugin_main():
     global PLUGIN_DEV_SKIP_VARIANT_CALLING


### PR DESCRIPTION
Move process_results() call into same for loop as variant_caller_pipeline() for non-multisample runs.

TVC 5.2 calls process_results() only after all barcodes have gone through the pipeline. This behavior differs from all previous TVC versions and means that XLS files and other report files will not be available until the very end. Clinical labs depend on being able to access resulting XLS files as the barcodes finish. 

This change should be relatively benign because variant_caller_pipeline() takes typically takes 10-20 times longer to execute than process_results().